### PR TITLE
fix(sanity): allow mailto contact links

### DIFF
--- a/sanity/schemas/contactInfo.ts
+++ b/sanity/schemas/contactInfo.ts
@@ -83,7 +83,10 @@ export default defineType({
               type: 'url',
               title: 'Link',
               description: 'Full URL (https://t.me/..., mailto:..., https://linkedin.com/...)',
-              validation: (Rule) => Rule.required(),
+              validation: (Rule) =>
+                Rule.required().uri({
+                  scheme: ['http', 'https', 'mailto', 'tel'],
+                }),
             },
             {
               name: 'description',


### PR DESCRIPTION
## What changed

- Allows `mailto:` and `tel:` schemes for Contact Info channel links in Sanity Studio.

## Why

Sanity's `url` validation was blocking email channel links such as `mailto:s.mytsyk@gmail.com`, so the Contact Info document could not be published.

## Validation

- `npm run build` passed locally before publishing this change.