### PR TITLE
Refresh services index for new AI pages

### DIFF
--- a/app/[lang]/services/page.tsx
+++ b/app/[lang]/services/page.tsx
@@ -1,34 +1,53 @@
 // app/[lang]/services/page.tsx
 import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, Sparkles } from 'lucide-react';
 import type { Locale } from '@/lib/i18n';
-import { servicesCopy } from '@/content/services.copy';
+import { servicesCopy, type Service, type ServicesCopy } from '@/content/services.copy';
 import { sanityClient } from '@/sanity/client';
-import { servicesQuery } from '@/sanity/queries';
+import { pageByPathQuery, servicesQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import Link from 'next/link';
 import JsonLd from '@/components/seo/json-ld';
 import { breadcrumbSchema } from '@/lib/schema';
 import type { ContactPurpose } from '@/content/site.copy';
+import { cn } from '@/lib/utils';
 
 type Props = { params: Promise<{ lang: Locale }> };
+
 type CmsService = {
-  slug: { current: string };
-  title: string;
-  description: string;
+  slug?: { current?: string };
+  title?: string;
+  description?: string;
   bullets?: string[];
   cta?: string;
   href?: string;
   featured?: boolean;
+  highlighted?: boolean;
 };
 
-function purposeForService(id: string): ContactPurpose {
-  if (id === 'ai-automation' || id === 'dashboards-reports') return 'price';
-  if (id === 'apps-script') return 'question';
-  return 'consultation';
-}
+type CmsServicesPage = {
+  title?: string;
+  description?: string;
+  seoTitle?: string;
+  seoDescription?: string;
+  content?: unknown;
+  cta?: {
+    primary?: string;
+    secondary?: string;
+  };
+};
+
+type ServicesPageContent = Partial<Omit<ServicesCopy, 'services'>>;
+
+const primaryServiceIds = new Set([
+  'ai-training',
+  'ai-business',
+  'ai-automation',
+  'ai-sheets-excel',
+]);
 
 const priorityLabel: Record<Locale, string> = {
   ru: 'Приоритет',
@@ -36,19 +55,195 @@ const priorityLabel: Record<Locale, string> = {
   ro: 'Prioritar',
 };
 
-export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { lang } = await params;
-  const t = servicesCopy[lang];
+function parseServicesPageContent(content: unknown): ServicesPageContent | undefined {
+  if (!content || typeof content !== 'object') return undefined;
 
-  const titles: Record<Locale, string> = {
-    ru: 'Услуги — Analyst Online',
-    ua: 'Послуги — Analyst Online',
-    ro: 'Servicii — Analyst Online',
-  };
+  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
+    try {
+      return JSON.parse(content.data) as ServicesPageContent;
+    } catch {
+      return undefined;
+    }
+  }
+
+  return content as ServicesPageContent;
+}
+
+function mergeServicesPageCopy(lang: Locale, cmsPage: CmsServicesPage | null): ServicesCopy {
+  const fallback = servicesCopy[lang];
+  const content = parseServicesPageContent(cmsPage?.content);
 
   return {
-    title: titles[lang],
-    description: t.pageSubtitle,
+    ...fallback,
+    heroBadge: content?.heroBadge ?? fallback.heroBadge,
+    pageTitle: content?.pageTitle ?? cmsPage?.title ?? fallback.pageTitle,
+    pageSubtitle: content?.pageSubtitle ?? cmsPage?.description ?? fallback.pageSubtitle,
+    heroPrimaryCta: content?.heroPrimaryCta ?? cmsPage?.cta?.primary ?? fallback.heroPrimaryCta,
+    heroSecondaryCta:
+      content?.heroSecondaryCta ?? cmsPage?.cta?.secondary ?? fallback.heroSecondaryCta,
+    primarySectionTitle: content?.primarySectionTitle ?? fallback.primarySectionTitle,
+    primarySectionSubtitle: content?.primarySectionSubtitle ?? fallback.primarySectionSubtitle,
+    supportSectionTitle: content?.supportSectionTitle ?? fallback.supportSectionTitle,
+    supportSectionSubtitle: content?.supportSectionSubtitle ?? fallback.supportSectionSubtitle,
+    ctaTitle: content?.ctaTitle ?? fallback.ctaTitle,
+    ctaSubtitle: content?.ctaSubtitle ?? fallback.ctaSubtitle,
+    ctaPrimary: content?.ctaPrimary ?? fallback.ctaPrimary,
+  };
+}
+
+async function loadServicesPageDoc(lang: Locale) {
+  if (!isSanityConfigured()) return null;
+
+  try {
+    return await sanityClient.fetch<CmsServicesPage | null>(
+      pageByPathQuery,
+      { locale: lang, path: 'services' },
+      { next: { tags: ['page'] } },
+    );
+  } catch (error) {
+    console.warn('Failed to fetch services page from Sanity CMS, using fallback:', error);
+    return null;
+  }
+}
+
+async function loadCmsServices(lang: Locale) {
+  if (!isSanityConfigured()) return null;
+
+  try {
+    return await sanityClient.fetch<CmsService[]>(
+      servicesQuery,
+      { locale: lang },
+      { next: { tags: ['service'] } },
+    );
+  } catch (error) {
+    console.warn('Failed to fetch services from Sanity CMS, using fallback:', error);
+    return null;
+  }
+}
+
+function mergeCmsServices(cmsServices: CmsService[] | null, fallbackServices: Service[]) {
+  if (!cmsServices || cmsServices.length === 0) return fallbackServices;
+
+  const cmsBySlug = new Map(
+    cmsServices
+      .map((service) => [service.slug?.current, service] as const)
+      .filter(([slug]) => Boolean(slug)),
+  );
+
+  return fallbackServices.map((fallback) => {
+    const cms = cmsBySlug.get(fallback.id);
+    if (!cms) return fallback;
+
+    return {
+      ...fallback,
+      title: cms.title ?? fallback.title,
+      description: cms.description ?? fallback.description,
+      bullets: cms.bullets && cms.bullets.length > 0 ? cms.bullets : fallback.bullets,
+      cta: cms.cta ?? fallback.cta,
+      href: cms.href ?? fallback.href,
+      highlighted: cms.highlighted ?? cms.featured ?? fallback.highlighted,
+    };
+  });
+}
+
+function purposeForService(id: string): ContactPurpose {
+  if (id === 'ai-automation' || id === 'dashboards-reports') return 'price';
+  if (id === 'apps-script') return 'question';
+  return 'consultation';
+}
+
+function hrefForService(lang: Locale, service: Service) {
+  if (!service.href) return `/${lang}/contact?purpose=${purposeForService(service.id)}`;
+  if (/^https?:\/\//.test(service.href)) return service.href;
+  if (service.href.startsWith(`/${lang}/`)) return service.href;
+
+  const normalizedHref = service.href.startsWith('/') ? service.href : `/${service.href}`;
+  return `/${lang}${normalizedHref}`;
+}
+
+async function loadServicesPage(lang: Locale) {
+  const [cmsPage, cmsServices] = await Promise.all([
+    loadServicesPageDoc(lang),
+    loadCmsServices(lang),
+  ]);
+  const pageCopy = mergeServicesPageCopy(lang, cmsPage);
+
+  return {
+    pageCopy,
+    services: mergeCmsServices(cmsServices, pageCopy.services),
+    seoTitle: cmsPage?.seoTitle,
+    seoDescription: cmsPage?.seoDescription,
+  };
+}
+
+function ServiceCard({
+  lang,
+  service,
+  compact = false,
+}: {
+  lang: Locale;
+  service: Service;
+  compact?: boolean;
+}) {
+  const href = hrefForService(lang, service);
+
+  return (
+    <Card
+      className={cn(
+        'h-full rounded-lg border bg-card shadow-sm transition-colors',
+        service.highlighted
+          ? 'border-primary/30 bg-primary/5'
+          : 'border-border hover:border-primary/25',
+      )}
+    >
+      <CardContent className={cn('flex h-full flex-col gap-4 p-6', compact ? 'md:p-6' : 'md:p-8')}>
+        <div className="flex items-start justify-between gap-3">
+          <h3 className={cn('font-bold text-foreground', compact ? 'text-lg' : 'text-xl')}>
+            {service.title}
+          </h3>
+          {service.highlighted ? (
+            <Badge variant="secondary" className="shrink-0 text-xs">
+              {priorityLabel[lang]}
+            </Badge>
+          ) : null}
+        </div>
+
+        <p className="leading-relaxed text-foreground/70">{service.description}</p>
+
+        <ul className="space-y-2">
+          {service.bullets.map((bullet) => (
+            <li key={bullet} className="flex items-start gap-2 text-sm text-foreground/80">
+              <CheckCircle2 size={16} className="mt-0.5 shrink-0 text-growth-green" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+
+        <div className="mt-auto pt-2">
+          <Button
+            className="font-bold"
+            variant={service.href ? 'default' : 'outline'}
+            size="sm"
+            asChild
+          >
+            <Link href={href}>
+              {service.cta}
+              <ArrowRight size={15} />
+            </Link>
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang } = await params;
+  const { pageCopy, seoTitle, seoDescription } = await loadServicesPage(lang);
+
+  return {
+    title: seoTitle ?? `${pageCopy.pageTitle} — Analyst Online`,
+    description: seoDescription ?? pageCopy.pageSubtitle,
     alternates: {
       canonical: `https://analyst-online.com/${lang}/services`,
       languages: {
@@ -62,106 +257,123 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function ServicesPage({ params }: Props) {
   const { lang } = await params;
-
-  // Fetch services from CMS
-  let cmsServices: CmsService[] | null = null;
-  if (isSanityConfigured()) {
-    try {
-      cmsServices = await sanityClient.fetch<CmsService[]>(
-        servicesQuery,
-        { locale: lang },
-        { next: { tags: ['service'] } },
-      );
-    } catch (error) {
-      console.warn('Failed to fetch services from Sanity CMS, using fallback:', error);
-    }
-  }
-
-  // Use CMS data if available, otherwise fallback to .copy.ts
-  const t = servicesCopy[lang];
-  const services =
-    cmsServices && cmsServices.length > 0
-      ? cmsServices.map((s) => ({
-          id: s.slug.current,
-          title: s.title,
-          description: s.description,
-          bullets: s.bullets || [],
-          cta: s.cta || t.ctaPrimary,
-          href: s.href,
-          highlighted: s.featured || false,
-        }))
-      : t.services;
+  const { pageCopy, services } = await loadServicesPage(lang);
+  const primaryServices = services.filter((service) => primaryServiceIds.has(service.id));
+  const supportServices = services.filter((service) => !primaryServiceIds.has(service.id));
 
   return (
-    <div className="page space-y-16 py-12">
+    <div>
       <JsonLd
         data={breadcrumbSchema([
           { name: 'Analyst Online', href: `/${lang}` },
-          { name: t.pageTitle, href: `/${lang}/services` },
+          { name: pageCopy.pageTitle, href: `/${lang}/services` },
         ])}
       />
 
-      {/* Header */}
-      <div className="max-w-2xl">
-        <h1 className="text-4xl font-bold tracking-tight md:text-5xl">{t.pageTitle}</h1>
-        <p className="mt-4 text-lg text-foreground/70">{t.pageSubtitle}</p>
-      </div>
+      <section className="border-b border-border bg-background py-16 md:py-24">
+        <div className="mx-auto grid max-w-6xl gap-10 px-4 sm:px-6 lg:grid-cols-[1fr_0.78fr] lg:items-end">
+          <div className="max-w-4xl">
+            <div className="inline-flex items-center gap-2 rounded-md border border-primary/20 bg-primary/5 px-3 py-1 text-xs font-semibold text-primary">
+              <Sparkles size={14} />
+              {pageCopy.heroBadge}
+            </div>
+            <h1 className="mt-5 text-4xl font-extrabold leading-tight text-foreground md:text-6xl">
+              {pageCopy.pageTitle}
+            </h1>
+            <p className="mt-5 max-w-3xl text-lg leading-relaxed text-foreground/70 md:text-xl">
+              {pageCopy.pageSubtitle}
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              {primaryServices[0] ? (
+                <Button size="lg" className="font-bold" asChild>
+                  <Link href={hrefForService(lang, primaryServices[0])}>
+                    {pageCopy.heroPrimaryCta}
+                    <ArrowRight size={17} />
+                  </Link>
+                </Button>
+              ) : null}
+              <Button size="lg" variant="outline" className="font-bold" asChild>
+                <Link href="#directions">{pageCopy.heroSecondaryCta}</Link>
+              </Button>
+            </div>
+          </div>
 
-      {/* Services grid */}
-      <div className="grid gap-6 md:grid-cols-2">
-        {services.map((service: (typeof t.services)[0]) => (
-          <Card
-            key={service.id}
-            className={`rounded-lg border bg-card transition-all duration-300 ${
-              service.highlighted
-                ? 'border-primary/25 bg-primary/5 hover:border-primary/40 hover:shadow-md'
-                : 'border-border hover:border-primary/20'
-            }`}
-          >
-            <CardContent className="space-y-4 p-6 md:p-8">
-              <div className="flex items-start justify-between gap-3">
-                <h2 className="text-xl font-semibold">{service.title}</h2>
-                {service.highlighted && (
-                  <Badge variant="secondary" className="shrink-0 text-xs">
-                    {priorityLabel[lang]}
-                  </Badge>
-                )}
-              </div>
-              <p className="leading-relaxed text-foreground/70">{service.description}</p>
-              <ul className="space-y-1.5">
-                {service.bullets.map((bullet, i) => (
-                  <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
-                    <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full bg-omni-cyan" />
-                    {bullet}
-                  </li>
-                ))}
-              </ul>
-              <div className="pt-2">
-                {service.href ? (
-                  <Button className="font-bold" asChild size="sm">
-                    <Link href={`/${lang}${service.href}`}>{service.cta}</Link>
-                  </Button>
-                ) : (
-                  <Button className="font-semibold" variant="outline" size="sm" asChild>
-                    <Link href={`/${lang}/contact?purpose=${purposeForService(service.id)}`}>
-                      {service.cta}
-                    </Link>
-                  </Button>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-1">
+            {primaryServices.map((service) => (
+              <Link
+                key={service.id}
+                href={hrefForService(lang, service)}
+                className="group rounded-lg border border-border bg-card p-4 shadow-sm transition-colors hover:border-primary/30"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <span className="text-sm font-bold text-foreground">{service.title}</span>
+                  <ArrowRight
+                    size={16}
+                    className="shrink-0 text-primary transition-transform group-hover:translate-x-0.5"
+                  />
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
 
-      {/* Bottom CTA */}
-      <div className="text-center space-y-4">
-        <h3 className="text-xl font-bold">{t.ctaTitle}</h3>
-        <p className="text-foreground/70">{t.ctaSubtitle}</p>
-        <Button className="px-8 font-bold" asChild>
-          <Link href={`/${lang}/contact?purpose=consultation`}>{t.ctaPrimary}</Link>
-        </Button>
-      </div>
+      <section id="directions" className="py-16 md:py-24">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="max-w-3xl">
+            <h2 className="text-3xl font-bold text-foreground md:text-4xl">
+              {pageCopy.primarySectionTitle}
+            </h2>
+            <p className="mt-3 leading-relaxed text-foreground/70">
+              {pageCopy.primarySectionSubtitle}
+            </p>
+          </div>
+
+          <div className="mt-8 grid gap-6 md:grid-cols-2">
+            {primaryServices.map((service) => (
+              <ServiceCard key={service.id} lang={lang} service={service} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {supportServices.length > 0 ? (
+        <section className="border-y border-border bg-card py-16 md:py-24">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6">
+            <div className="max-w-3xl">
+              <h2 className="text-3xl font-bold text-foreground md:text-4xl">
+                {pageCopy.supportSectionTitle}
+              </h2>
+              <p className="mt-3 leading-relaxed text-foreground/70">
+                {pageCopy.supportSectionSubtitle}
+              </p>
+            </div>
+
+            <div className="mt-8 grid gap-5 md:grid-cols-2">
+              {supportServices.map((service) => (
+                <ServiceCard key={service.id} lang={lang} service={service} compact />
+              ))}
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      <section className="py-16 md:py-24">
+        <div className="mx-auto max-w-4xl px-4 text-center sm:px-6">
+          <h2 className="text-3xl font-bold text-foreground">{pageCopy.ctaTitle}</h2>
+          <p className="mx-auto mt-3 max-w-2xl leading-relaxed text-foreground/70">
+            {pageCopy.ctaSubtitle}
+          </p>
+          <div className="mt-8">
+            <Button size="lg" className="font-bold" asChild>
+              <Link href={`/${lang}/contact?purpose=consultation`}>
+                {pageCopy.ctaPrimary}
+                <ArrowRight size={17} />
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </section>
     </div>
   );
 }

--- a/content/services.copy.ts
+++ b/content/services.copy.ts
@@ -11,8 +11,15 @@ export type Service = {
 };
 
 export type ServicesCopy = {
+  heroBadge: string;
   pageTitle: string;
   pageSubtitle: string;
+  heroPrimaryCta: string;
+  heroSecondaryCta: string;
+  primarySectionTitle: string;
+  primarySectionSubtitle: string;
+  supportSectionTitle: string;
+  supportSectionSubtitle: string;
   services: Service[];
   ctaTitle: string;
   ctaSubtitle: string;
@@ -21,9 +28,18 @@ export type ServicesCopy = {
 
 export const servicesCopy: Record<Locale, ServicesCopy> = {
   ru: {
-    pageTitle: 'Услуги',
+    heroBadge: 'Новая версия Analyst Online',
+    pageTitle: 'AI, автоматизация и аналитика для бизнеса',
     pageSubtitle:
       'Команда Analyst Online помогает внедрять AI, автоматизировать отчёты, строить аналитику и закрывать регулярные задачи бизнеса без найма full-time специалиста.',
+    heroPrimaryCta: 'Начать с AI обучения',
+    heroSecondaryCta: 'Посмотреть направления',
+    primarySectionTitle: 'Новые AI SEO направления',
+    primarySectionSubtitle:
+      'Отдельные страницы для обучения, AI-внедрения, автоматизации и работы с Google Sheets / Excel.',
+    supportSectionTitle: 'Поддержка внедрения',
+    supportSectionSubtitle:
+      'Форматы, которые помогают довести AI, аналитику и отчётность до регулярной работы в команде.',
     services: [
       {
         id: 'ai-training',
@@ -143,9 +159,18 @@ export const servicesCopy: Record<Locale, ServicesCopy> = {
   },
 
   ua: {
-    pageTitle: 'Послуги',
+    heroBadge: 'Нова версія Analyst Online',
+    pageTitle: 'AI, автоматизація та аналітика для бізнесу',
     pageSubtitle:
       'Команда Analyst Online допомагає впроваджувати AI, автоматизувати звіти, будувати аналітику й закривати регулярні задачі бізнесу без найму full-time спеціаліста.',
+    heroPrimaryCta: 'Почати з AI навчання',
+    heroSecondaryCta: 'Переглянути напрями',
+    primarySectionTitle: 'Нові AI SEO напрями',
+    primarySectionSubtitle:
+      'Окремі сторінки для навчання, AI-впровадження, автоматизації та роботи з Google Sheets / Excel.',
+    supportSectionTitle: 'Підтримка впровадження',
+    supportSectionSubtitle:
+      'Формати, які допомагають довести AI, аналітику та звітність до регулярної роботи в команді.',
     services: [
       {
         id: 'ai-training',
@@ -265,9 +290,18 @@ export const servicesCopy: Record<Locale, ServicesCopy> = {
   },
 
   ro: {
-    pageTitle: 'Servicii',
+    heroBadge: 'Noua versiune Analyst Online',
+    pageTitle: 'AI, automatizare și analytics pentru business',
     pageSubtitle:
       'Echipa Analyst Online ajută la implementarea AI, automatizarea rapoartelor, construirea analytics-ului și acoperirea sarcinilor recurente fără angajarea unui analist full-time.',
+    heroPrimaryCta: 'Începe cu training AI',
+    heroSecondaryCta: 'Vezi direcțiile',
+    primarySectionTitle: 'Noile direcții AI SEO',
+    primarySectionSubtitle:
+      'Pagini separate pentru training, implementare AI, automatizare și lucru cu Google Sheets / Excel.',
+    supportSectionTitle: 'Suport pentru implementare',
+    supportSectionSubtitle:
+      'Formate care ajută echipa să transforme AI, analytics-ul și raportarea în lucru recurent.',
     services: [
       {
         id: 'ai-training',

--- a/sanity/migrate.ts
+++ b/sanity/migrate.ts
@@ -28,18 +28,48 @@ const locales: Locale[] = ['ru', 'ua', 'ro'];
 
 type SluggedDocument = {
   _type: string;
-  slug: { current: string };
+  slug: { _type?: string; current: string };
   locale: string;
+  [key: string]: unknown;
 };
+
+type ServicesPageContent = Omit<(typeof servicesCopy)['ru'], 'services'>;
+
+function getServicesPageContent(locale: Locale): ServicesPageContent {
+  const copy = servicesCopy[locale];
+
+  return {
+    heroBadge: copy.heroBadge,
+    pageTitle: copy.pageTitle,
+    pageSubtitle: copy.pageSubtitle,
+    heroPrimaryCta: copy.heroPrimaryCta,
+    heroSecondaryCta: copy.heroSecondaryCta,
+    primarySectionTitle: copy.primarySectionTitle,
+    primarySectionSubtitle: copy.primarySectionSubtitle,
+    supportSectionTitle: copy.supportSectionTitle,
+    supportSectionSubtitle: copy.supportSectionSubtitle,
+    ctaTitle: copy.ctaTitle,
+    ctaSubtitle: copy.ctaSubtitle,
+    ctaPrimary: copy.ctaPrimary,
+  };
+}
 
 // ============================================================================
 // Helper functions
 // ============================================================================
 
-async function documentExists(type: string, slug: string, locale: string): Promise<boolean> {
+async function findDocumentIdBySlug(
+  type: string,
+  slug: string,
+  locale: string,
+): Promise<string | null> {
   const query = `*[_type == $type && slug.current == $slug && locale == $locale][0]._id`;
   const result = await client.fetch(query, { type, slug, locale });
-  return !!result;
+  return result ?? null;
+}
+
+async function documentExists(type: string, slug: string, locale: string): Promise<boolean> {
+  return Boolean(await findDocumentIdBySlug(type, slug, locale));
 }
 
 async function createOrSkip(doc: SluggedDocument, label: string) {
@@ -50,6 +80,21 @@ async function createOrSkip(doc: SluggedDocument, label: string) {
   }
   await client.create(doc);
   console.log(`✅ Created: ${label}`);
+}
+
+async function upsertBySlug(doc: SluggedDocument, label: string) {
+  const existingId = await findDocumentIdBySlug(doc._type, doc.slug.current, doc.locale);
+
+  if (!existingId) {
+    await client.create(doc);
+    console.log(`✅ Created: ${label}`);
+    return;
+  }
+
+  const patch: Record<string, unknown> = { ...doc };
+  delete patch._type;
+  await client.patch(existingId).set(patch).commit();
+  console.log(`🔁 Updated: ${label}`);
 }
 
 // ============================================================================
@@ -87,6 +132,47 @@ async function migrateHomePage() {
 }
 
 // ============================================================================
+// Migrate Services index page
+// ============================================================================
+
+async function migrateServicesPage() {
+  console.log('\n📄 Migrating Services index page...');
+
+  for (const locale of locales) {
+    const copy = servicesCopy[locale];
+    const pageContent = getServicesPageContent(locale);
+
+    const doc = {
+      _type: 'page',
+      slug: { _type: 'slug', current: 'services' },
+      locale,
+      title: copy.pageTitle,
+      description: copy.pageSubtitle,
+      routePath: 'services',
+      pageType: 'services',
+      status: 'published',
+      seoTitle: `${copy.pageTitle} — Analyst Online`,
+      seoDescription: copy.pageSubtitle,
+      content: { data: JSON.stringify(pageContent, null, 2) },
+      cta: {
+        primary: copy.heroPrimaryCta,
+        secondary: copy.heroSecondaryCta,
+      },
+      body: [
+        {
+          _type: 'block',
+          _key: `services-${locale}-intro`,
+          style: 'normal',
+          children: [{ _type: 'span', text: copy.pageSubtitle }],
+        },
+      ],
+    };
+
+    await upsertBySlug(doc, `Services index (${locale})`);
+  }
+}
+
+// ============================================================================
 // Migrate Services
 // ============================================================================
 
@@ -110,10 +196,11 @@ async function migrateServices() {
         cta: service.cta,
         href: service.href,
         featured: service.highlighted || false,
+        highlighted: service.highlighted || false,
         order: i,
       };
 
-      await createOrSkip(doc, `Service: ${service.id} (${locale})`);
+      await upsertBySlug(doc, `Service: ${service.id} (${locale})`);
     }
   }
 }
@@ -517,6 +604,7 @@ async function migrate() {
 
   try {
     await migrateHomePage();
+    await migrateServicesPage();
     await migrateServices();
     await migrateOfferPages();
     await migrateOmniDashBlocks();

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -122,6 +122,7 @@ export const servicesQuery = groq`
     bullets,
     cta,
     href,
+    highlighted,
     featured,
     order
   }
@@ -138,6 +139,7 @@ export const serviceBySlugQuery = groq`
     bullets,
     cta,
     href,
+    highlighted,
     featured,
     order
   }

--- a/sanity/schemas/service.ts
+++ b/sanity/schemas/service.ts
@@ -83,6 +83,13 @@ export default defineType({
       description: 'Show on home page',
       initialValue: false,
     }),
+    defineField({
+      name: 'highlighted',
+      title: 'Highlighted on services page',
+      type: 'boolean',
+      description: 'Visually emphasize this service on the /services index page',
+      initialValue: false,
+    }),
   ],
   orderings: [
     {


### PR DESCRIPTION
## What changed
- Reworked `/[lang]/services` around the new Analyst Online AI/automation positioning.
- Added prominent links to the localized AI training pages and all three localized service SEO pages.
- Made the services index page read page-level copy from Sanity `page` documents and card copy from current `service` documents.
- Guarded the page against old/stale Sanity service docs by merging only the current service IDs from `services.copy.ts`.
- Added Sanity seed/upsert support for the services index page and the refreshed services.

## CMS
- Ran `npm run migrate-content` against Sanity production.
- Created `Services index` documents for `ru`, `ua`, `ro`.
- Created/updated current `service` documents and created the new offer page documents.

## Validation
- `npm run format:check`
- `npm run lint`
- `npm run build`
- Local HTTP checks for `/ru/services`, `/ua/services`, `/ro/services` confirmed all new localized links are present.