### PR TITLE
[codex] Refresh published CMS page content

### DIFF
--- a/app/[lang]/[...slug]/page.tsx
+++ b/app/[lang]/[...slug]/page.tsx
@@ -13,6 +13,7 @@ import { breadcrumbSchema, serviceSchema } from '@/lib/schema';
 import { sanityClient } from '@/sanity/client';
 import { pageByPathQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { parseJsonPageContent, sanityFetchOptions } from '@/sanity/fetch';
 import { siteCopy } from '@/content/site.copy';
 import type { SanityImageValue } from '@/sanity/image';
 import { socialPreviewMetadata } from '@/lib/seo-metadata';
@@ -32,19 +33,6 @@ type CmsOfferPage = {
   content?: unknown;
 };
 
-function parseCmsContent(content: unknown): Partial<OfferPageCopy> | undefined {
-  if (!content || typeof content !== 'object') return undefined;
-  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
-    try {
-      return JSON.parse(content.data) as Partial<OfferPageCopy>;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return content as Partial<OfferPageCopy>;
-}
-
 function mergePageCopy(
   lang: Locale,
   path: string,
@@ -53,7 +41,7 @@ function mergePageCopy(
 ): OfferPageCopy | null {
   if (!cmsData && !fallback) return null;
 
-  const cmsContent = parseCmsContent(cmsData?.content);
+  const cmsContent = parseJsonPageContent<OfferPageCopy>(cmsData?.content, `offer page ${path}`);
   const title = cmsContent?.title ?? cmsData?.title ?? fallback?.title ?? path;
   const description =
     cmsContent?.description ??
@@ -92,7 +80,7 @@ async function loadPage(lang: Locale, path: string) {
     const cmsData = await sanityClient.fetch<CmsOfferPage | null>(
       pageByPathQuery,
       { locale: lang, path },
-      { next: { tags: ['page'] } },
+      sanityFetchOptions('page'),
     );
 
     return {

--- a/app/[lang]/blog/[slug]/page.tsx
+++ b/app/[lang]/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { sanityClient } from '@/sanity/client';
 import { urlFor } from '@/sanity/image';
 import { blogPostQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { sanityFetchOptions } from '@/sanity/fetch';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
 import PostHeader from '@/components/blog/post-header';
@@ -78,7 +79,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   try {
-    const post = await sanityClient.fetch<BlogPost | null>(blogPostQuery, { locale: lang, slug });
+    const post = await sanityClient.fetch<BlogPost | null>(
+      blogPostQuery,
+      { locale: lang, slug },
+      sanityFetchOptions('blogPost'),
+    );
 
     if (!post) {
       return {
@@ -181,7 +186,7 @@ export default async function BlogPostPage({ params }: Props) {
     post = await sanityClient.fetch<BlogPost | null>(
       blogPostQuery,
       { locale: lang, slug },
-      { next: { tags: ['blogPost'] } },
+      sanityFetchOptions('blogPost'),
     );
   } catch (error) {
     console.error('Failed to fetch blog post:', error);

--- a/app/[lang]/blog/page.tsx
+++ b/app/[lang]/blog/page.tsx
@@ -4,6 +4,7 @@ import type { Locale } from '@/lib/i18n';
 import { sanityClient } from '@/sanity/client';
 import { blogListQuery, pageByPathQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { sanityFetchOptions } from '@/sanity/fetch';
 import PostCard from '@/components/blog/post-card';
 import JsonLd from '@/components/seo/json-ld';
 import { breadcrumbSchema } from '@/lib/schema';
@@ -66,7 +67,7 @@ async function loadBlogPageDoc(lang: Locale) {
     return await sanityClient.fetch<CmsBlogPage | null>(
       pageByPathQuery,
       { locale: lang, path: 'blog' },
-      { next: { tags: ['page'] } },
+      sanityFetchOptions('page'),
     );
   } catch (error) {
     console.warn('Failed to fetch blog page from Sanity CMS, using fallback:', error);
@@ -121,7 +122,7 @@ export default async function BlogPage({ params }: Props) {
       posts = await sanityClient.fetch<BlogListPost[]>(
         blogListQuery,
         { locale: lang },
-        { next: { tags: ['blogPost'] } },
+        sanityFetchOptions('blogPost'),
       );
     } catch (error) {
       console.warn('Failed to fetch blog posts from Sanity CMS:', error);

--- a/app/[lang]/cases/page.tsx
+++ b/app/[lang]/cases/page.tsx
@@ -11,6 +11,7 @@ import { breadcrumbSchema } from '@/lib/schema';
 import { sanityClient } from '@/sanity/client';
 import { casesPageQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { parseJsonPageContent, sanityFetchOptions } from '@/sanity/fetch';
 import type { SanityImageValue } from '@/sanity/image';
 import { socialPreviewMetadata } from '@/lib/seo-metadata';
 
@@ -25,19 +26,6 @@ type CmsCasesPage = {
   content?: unknown;
 };
 
-function parseCmsContent(content: unknown): Partial<CasesCopy> | undefined {
-  if (!content || typeof content !== 'object') return undefined;
-  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
-    try {
-      return JSON.parse(content.data) as Partial<CasesCopy>;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return content as Partial<CasesCopy>;
-}
-
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang } = await params;
   const t = casesCopy[lang];
@@ -48,7 +36,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       cmsData = await sanityClient.fetch<CmsCasesPage | null>(
         casesPageQuery,
         { locale: lang },
-        { next: { tags: ['page'] } },
+        sanityFetchOptions('page'),
       );
     } catch (error) {
       console.warn('Failed to fetch cases metadata from Sanity CMS, using fallback:', error);
@@ -89,13 +77,13 @@ export default async function CasesPage({ params }: Props) {
       const cmsData = await sanityClient.fetch<CmsCasesPage | null>(
         casesPageQuery,
         { locale: lang },
-        { next: { tags: ['page'] } },
+        sanityFetchOptions('page'),
       );
 
       if (cmsData) {
         t = {
           ...t,
-          ...parseCmsContent(cmsData.content),
+          ...parseJsonPageContent<CasesCopy>(cmsData.content, `cases page (${lang})`),
           pageTitle: cmsData.title ?? t.pageTitle,
           pageSubtitle: cmsData.description ?? t.pageSubtitle,
         };

--- a/app/[lang]/contact/page.tsx
+++ b/app/[lang]/contact/page.tsx
@@ -11,6 +11,7 @@ import ContactForm from '@/components/contact/contact-form';
 import { sanityClient } from '@/sanity/client';
 import { contactInfoQuery, contactPageQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { sanityFetchOptions } from '@/sanity/fetch';
 import { createContactFormToken } from '@/lib/contact-security';
 import type { SanityImageValue } from '@/sanity/image';
 import { socialPreviewMetadata } from '@/lib/seo-metadata';
@@ -44,7 +45,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       cmsPage = await sanityClient.fetch<CmsContactPage | null>(
         contactPageQuery,
         { locale: lang },
-        { next: { tags: ['page'] } },
+        sanityFetchOptions('page'),
       );
     } catch (error) {
       console.warn('Failed to fetch contact metadata from Sanity CMS, using fallback:', error);
@@ -101,7 +102,7 @@ export default async function ContactPage({ params, searchParams }: Props) {
       const cmsData = await sanityClient.fetch(
         contactInfoQuery,
         { locale: lang },
-        { next: { tags: ['contactInfo'] } },
+        sanityFetchOptions('contactInfo'),
       );
 
       if (cmsData) {

--- a/app/[lang]/omnidash/page.tsx
+++ b/app/[lang]/omnidash/page.tsx
@@ -6,6 +6,7 @@ import type { OmniDashCopy } from '@/content/omnidash.copy';
 import { sanityClient } from '@/sanity/client';
 import { omnidashBlocksQuery, faqQuery, pageByPathQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { sanityFetchOptions } from '@/sanity/fetch';
 import type { SanityImageValue } from '@/sanity/image';
 import { socialPreviewMetadata } from '@/lib/seo-metadata';
 
@@ -84,7 +85,7 @@ async function loadOmniDashPageDoc(lang: Locale) {
     return await sanityClient.fetch<CmsOmniDashPage | null>(
       pageByPathQuery,
       { locale: lang, path: 'omnidash' },
-      { next: { tags: ['page'] } },
+      sanityFetchOptions('page'),
     );
   } catch (error) {
     console.warn('Failed to fetch OmniDash page from Sanity CMS, using fallback:', error);
@@ -211,12 +212,12 @@ export default async function OmniDashPage({ params }: Props) {
         sanityClient.fetch<CmsOmniDashBlock[]>(
           omnidashBlocksQuery,
           { locale: lang },
-          { next: { tags: ['omnidashBlock'] } },
+          sanityFetchOptions('omnidashBlock'),
         ),
         sanityClient.fetch<CmsFaqItem[]>(
           faqQuery,
           { locale: lang, category: 'omnidash' },
-          { next: { tags: ['faq'] } },
+          sanityFetchOptions('faq'),
         ),
         loadOmniDashPageDoc(lang),
       ]);

--- a/app/[lang]/page.tsx
+++ b/app/[lang]/page.tsx
@@ -6,6 +6,7 @@ import type { HomeCopy } from '@/content/home.copy';
 import { sanityClient } from '@/sanity/client';
 import { homePageQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { parseJsonPageContent, sanityFetchOptions } from '@/sanity/fetch';
 
 import JsonLd from '@/components/seo/json-ld';
 import { organizationSchema } from '@/lib/schema';
@@ -32,19 +33,6 @@ type CmsHomePage = {
   media?: CmsPageMediaItem[];
 };
 
-function parseCmsContent(content: unknown): Partial<HomeCopy> | undefined {
-  if (!content || typeof content !== 'object') return undefined;
-  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
-    try {
-      return JSON.parse(content.data) as Partial<HomeCopy>;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return content as Partial<HomeCopy>;
-}
-
 async function loadHomePageDoc(lang: Locale) {
   if (!isSanityConfigured()) return null;
 
@@ -52,7 +40,7 @@ async function loadHomePageDoc(lang: Locale) {
     return await sanityClient.fetch<CmsHomePage | null>(
       homePageQuery,
       { locale: lang },
-      { next: { tags: ['page'] } },
+      sanityFetchOptions('page'),
     );
   } catch (error) {
     console.warn('Failed to fetch home page from Sanity CMS, using fallback:', error);
@@ -99,7 +87,7 @@ export default async function LangHome({ params }: Props) {
   const t = cmsData
     ? {
         ...homeCopy[lang],
-        ...parseCmsContent(cmsData.content),
+        ...parseJsonPageContent<HomeCopy>(cmsData.content, `home page (${lang})`),
         heroTitle: cmsData.title ?? homeCopy[lang].heroTitle,
         heroSubtitle: cmsData.description ?? homeCopy[lang].heroSubtitle,
       }

--- a/app/[lang]/privacy/page.tsx
+++ b/app/[lang]/privacy/page.tsx
@@ -8,6 +8,7 @@ import { breadcrumbSchema } from '@/lib/schema';
 import { sanityClient } from '@/sanity/client';
 import { privacyPageQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { parseJsonPageContent, sanityFetchOptions } from '@/sanity/fetch';
 import type { SanityImageValue } from '@/sanity/image';
 import { socialPreviewMetadata } from '@/lib/seo-metadata';
 
@@ -22,19 +23,6 @@ type CmsPrivacyPage = {
   content?: unknown;
 };
 
-function parseCmsContent(content: unknown): Partial<PrivacyCopy> | undefined {
-  if (!content || typeof content !== 'object') return undefined;
-  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
-    try {
-      return JSON.parse(content.data) as Partial<PrivacyCopy>;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return content as Partial<PrivacyCopy>;
-}
-
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { lang } = await params;
   const t = privacyCopy[lang];
@@ -45,7 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       cmsData = await sanityClient.fetch<CmsPrivacyPage | null>(
         privacyPageQuery,
         { locale: lang },
-        { next: { tags: ['page'] } },
+        sanityFetchOptions('page'),
       );
     } catch (error) {
       console.warn('Failed to fetch privacy metadata from Sanity CMS, using fallback:', error);
@@ -86,13 +74,13 @@ export default async function PrivacyPage({ params }: Props) {
       const cmsData = await sanityClient.fetch<CmsPrivacyPage | null>(
         privacyPageQuery,
         { locale: lang },
-        { next: { tags: ['page'] } },
+        sanityFetchOptions('page'),
       );
 
       if (cmsData) {
         t = {
           ...t,
-          ...parseCmsContent(cmsData.content),
+          ...parseJsonPageContent<PrivacyCopy>(cmsData.content, `privacy page (${lang})`),
           pageTitle: cmsData.title ?? t.pageTitle,
           pageSubtitle: cmsData.description ?? t.pageSubtitle,
         };

--- a/app/[lang]/services/page.tsx
+++ b/app/[lang]/services/page.tsx
@@ -7,6 +7,7 @@ import { servicesCopy, type Service, type ServicesCopy } from '@/content/service
 import { sanityClient } from '@/sanity/client';
 import { pageByPathQuery, servicesQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { parseJsonPageContent, sanityFetchOptions } from '@/sanity/fetch';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -59,23 +60,12 @@ const priorityLabel: Record<Locale, string> = {
   ro: 'Prioritar',
 };
 
-function parseServicesPageContent(content: unknown): ServicesPageContent | undefined {
-  if (!content || typeof content !== 'object') return undefined;
-
-  if ('data' in content && typeof content.data === 'string' && content.data.trim()) {
-    try {
-      return JSON.parse(content.data) as ServicesPageContent;
-    } catch {
-      return undefined;
-    }
-  }
-
-  return content as ServicesPageContent;
-}
-
 function mergeServicesPageCopy(lang: Locale, cmsPage: CmsServicesPage | null): ServicesCopy {
   const fallback = servicesCopy[lang];
-  const content = parseServicesPageContent(cmsPage?.content);
+  const content = parseJsonPageContent<ServicesPageContent>(
+    cmsPage?.content,
+    `services page (${lang})`,
+  );
 
   return {
     ...fallback,
@@ -102,7 +92,7 @@ async function loadServicesPageDoc(lang: Locale) {
     return await sanityClient.fetch<CmsServicesPage | null>(
       pageByPathQuery,
       { locale: lang, path: 'services' },
-      { next: { tags: ['page'] } },
+      sanityFetchOptions('page'),
     );
   } catch (error) {
     console.warn('Failed to fetch services page from Sanity CMS, using fallback:', error);
@@ -117,7 +107,7 @@ async function loadCmsServices(lang: Locale) {
     return await sanityClient.fetch<CmsService[]>(
       servicesQuery,
       { locale: lang },
-      { next: { tags: ['service'] } },
+      sanityFetchOptions('service'),
     );
   } catch (error) {
     console.warn('Failed to fetch services from Sanity CMS, using fallback:', error);

--- a/app/api/revalidate/route.ts
+++ b/app/api/revalidate/route.ts
@@ -1,7 +1,8 @@
 // app/api/revalidate/route.ts
-import { revalidatePath } from 'next/cache';
+import { revalidatePath, revalidateTag } from 'next/cache';
 import { NextRequest, NextResponse } from 'next/server';
 import { parseBody } from 'next-sanity/webhook';
+import { CMS_CONTENT_TAGS } from '@/sanity/fetch';
 
 type SanityWebhookBody = {
   _type: string;
@@ -30,6 +31,7 @@ export async function POST(req: NextRequest) {
 
     const type = body._type;
     revalidatePath('/', 'layout');
+    CMS_CONTENT_TAGS.forEach((tag) => revalidateTag(tag, { expire: 0 }));
 
     console.log(`Revalidated for type: ${type}`);
 

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -4,6 +4,7 @@ import { LOCALES } from '@/lib/i18n';
 import { sanityClient } from '@/sanity/client';
 import { allBlogPostsForSitemapQuery, allPagesForSitemapQuery } from '@/sanity/queries';
 import { isSanityConfigured } from '@/sanity/config';
+import { sanityFetchOptions } from '@/sanity/fetch';
 import { getAllOfferPages, getOfferAlternates } from '@/content/offer-pages.copy';
 
 const BASE_URL = 'https://analyst-online.com';
@@ -72,7 +73,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (isSanityConfigured()) {
     try {
       const knownUrls = new Set(entries.map((entry) => entry.url));
-      const pages = await sanityClient.fetch<CmsSitemapPage[]>(allPagesForSitemapQuery);
+      const pages = await sanityClient.fetch<CmsSitemapPage[]>(
+        allPagesForSitemapQuery,
+        {},
+        sanityFetchOptions('page'),
+      );
 
       for (const page of pages) {
         const routePath = page.routePath || (page.slug === 'home' ? '' : page.slug);
@@ -89,7 +94,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
         }
       }
 
-      const posts = await sanityClient.fetch<CmsSitemapPost[]>(allBlogPostsForSitemapQuery);
+      const posts = await sanityClient.fetch<CmsSitemapPost[]>(
+        allBlogPostsForSitemapQuery,
+        {},
+        sanityFetchOptions('blogPost'),
+      );
       for (const post of posts) {
         entries.push({
           url: `${BASE_URL}/${post.locale}/blog/${post.slug}`,

--- a/sanity/config.ts
+++ b/sanity/config.ts
@@ -3,7 +3,7 @@ export const sanityConfig = {
   projectId: process.env.NEXT_PUBLIC_SANITY_PROJECT_ID || 'placeholder',
   dataset: process.env.NEXT_PUBLIC_SANITY_DATASET ?? 'production',
   apiVersion: '2024-01-01',
-  useCdn: process.env.NODE_ENV === 'production',
+  useCdn: false,
 };
 
 export const isSanityConfigured = () => {

--- a/sanity/fetch.ts
+++ b/sanity/fetch.ts
@@ -1,0 +1,40 @@
+export const CMS_REVALIDATE_SECONDS = 60;
+
+export const CMS_CONTENT_TAGS = [
+  'page',
+  'service',
+  'blogPost',
+  'contactInfo',
+  'omnidashBlock',
+  'faq',
+] as const;
+
+export function sanityFetchOptions(tags: string | string[]) {
+  return {
+    cache: 'force-cache' as const,
+    next: {
+      revalidate: CMS_REVALIDATE_SECONDS,
+      tags: Array.isArray(tags) ? tags : [tags],
+    },
+  };
+}
+
+export function parseJsonPageContent<T>(content: unknown, context: string): Partial<T> | undefined {
+  if (!content || typeof content !== 'object') return undefined;
+
+  if ('data' in content) {
+    const data = (content as { data?: unknown }).data;
+
+    if (typeof data !== 'string' || !data.trim()) return undefined;
+
+    try {
+      return JSON.parse(data) as Partial<T>;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`Invalid CMS JSON Data for ${context}: ${message}`);
+      return undefined;
+    }
+  }
+
+  return content as Partial<T>;
+}

--- a/sanity/queries.ts
+++ b/sanity/queries.ts
@@ -6,7 +6,7 @@ import { groq } from 'next-sanity';
 // ============================================================================
 
 export const homePageQuery = groq`
-  *[_type == "page" && slug.current == "home" && locale == $locale][0] {
+  *[_type == "page" && slug.current == "home" && locale == $locale && coalesce(status, "published") == "published"][0] {
     _id,
     title,
     description,
@@ -89,7 +89,7 @@ export const pageByPathQuery = groq`
 `;
 
 export const privacyPageQuery = groq`
-  *[_type == "page" && slug.current == "privacy" && locale == $locale][0] {
+  *[_type == "page" && slug.current == "privacy" && locale == $locale && coalesce(status, "published") == "published"][0] {
     _id,
     title,
     description,
@@ -109,7 +109,7 @@ export const privacyPageQuery = groq`
 `;
 
 export const contactPageQuery = groq`
-  *[_type == "page" && slug.current == "contact" && locale == $locale][0] {
+  *[_type == "page" && slug.current == "contact" && locale == $locale && coalesce(status, "published") == "published"][0] {
     _id,
     title,
     description,
@@ -165,7 +165,7 @@ export const contactInfoQuery = groq`
 `;
 
 export const casesPageQuery = groq`
-  *[_type == "page" && slug.current == "cases" && locale == $locale][0] {
+  *[_type == "page" && slug.current == "cases" && locale == $locale && coalesce(status, "published") == "published"][0] {
     _id,
     title,
     description,
@@ -366,7 +366,7 @@ export const blogPostQuery = groq`
 // ============================================================================
 
 export const allPagesForSitemapQuery = groq`
-  *[_type == "page" && defined(slug)] {
+  *[_type == "page" && defined(slug) && coalesce(status, "published") == "published"] {
     "slug": slug.current,
     routePath,
     locale,

--- a/sanity/schemas/page.ts
+++ b/sanity/schemas/page.ts
@@ -96,6 +96,17 @@ export default defineType({
           type: 'text',
           rows: 12,
           description: 'Optional JSON object for structured sections and CTA/FAQ blocks.',
+          validation: (Rule) =>
+            Rule.custom((value) => {
+              if (!value || typeof value !== 'string' || !value.trim()) return true;
+
+              try {
+                JSON.parse(value);
+                return true;
+              } catch {
+                return 'JSON Data must be valid JSON. Escape quotes inside strings as \\".';
+              }
+            }),
         },
       ],
     }),


### PR DESCRIPTION
## What changed

- Added a shared Sanity fetch/content parser helper with 60-second revalidation.
- Switched server-side Sanity reads away from the Sanity CDN so published content is read fresh.
- Revalidated all CMS cache tags from the Sanity webhook route.
- Added Studio validation for `page.content.data` so invalid JSON is caught before publish.
- Filtered page queries and sitemap page entries to published pages.

## Why

Home content edits in Sanity could silently fall back to hardcoded copy when `JSON Data` was invalid, and cached tagged fetches were not fully invalidated by the webhook. This made published CMS edits appear stale on the site.

## Validation

- `npm run lint`
- `npm run build`
- Prettier check for changed files

## Notes

The current Russian home `JSON Data` still needs the CMS value fixed from `без "воды"` with unescaped quotes to valid JSON, for example `без \"воды\"`.